### PR TITLE
Add journaling, MT5 data feed, GUI and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+
+# pytest cache
+.pytest_cache/
+journal.csv

--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
-# tradingbot
+# Trading Bot Example
+
+This repository contains a small educational implementation of a EUR/USD scalping strategy.  
+The core logic lives in `scalping_bot.py` and demonstrates how to calculate indicators and
+produce simple trade signals.
+
+## Strategy Overview
+
+- Trade only during the London session (08:00–16:00 BST) and the London/New York overlap
+  (13:00–16:00 BST).
+- **Buy** setup:
+  - Price above the 20‑SMA, 50‑SMA and 60‑EMA.
+  - 20‑SMA above 50‑SMA.
+  - RSI(14) above 50.
+  - Bullish candlestick pattern closing above the moving averages.
+- **Sell** setup: reverse the above conditions.
+- Risk exactly 2% of account balance per trade using a 10–15 pip stop and 20 pip target.
+
+The project is for educational use and does **not** execute real trades without further broker
+integration.
+
+## Trade Journal
+
+Each trade is appended to `journal.csv` in the project directory.  The first call writes
+CSV headers automatically.  You can change the journal path when creating the `ScalpingBot`:
+
+```python
+bot = ScalpingBot(balance=10000, journal_path="my_journal.csv")
+```
+
+## MetaTrader 5 Data
+
+An optional module `mt5_feed.py` can download historical data from MetaTrader 5.  Set the
+credentials in the environment variables `MT5_LOGIN`, `MT5_PASSWORD` and `MT5_SERVER` before
+running:
+
+```bash
+export MT5_LOGIN=123456
+export MT5_PASSWORD=secret
+export MT5_SERVER=Broker-Server
+```
+
+Then call `load_mt5_data(symbol, start, end)` to obtain a DataFrame compatible with
+`ScalpingBot.evaluate_signals`.
+
+## Web Interface
+
+A simple Flask app in `app.py` allows uploading CSV data or downloading candles from MT5 and
+running the strategy.  Start it locally with:
+
+```bash
+pip install flask MetaTrader5
+python app.py
+```
+
+Open <http://localhost:5000/> to view recent trades and trigger backtests.
+
+## Hosting on Netlify
+
+The `templates/` directory contains a very small static front‑end.  You can deploy those
+static files to Netlify for free.  Note that Netlify only hosts static content—it cannot run
+the Python trading logic.  Deploy by connecting your repository and using the default build
+command with the publish directory set to `templates`.  A minimal `netlify.toml` is included.
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,42 @@
+from flask import Flask, render_template, request, redirect, url_for
+import pandas as pd
+from scalping_bot import ScalpingBot
+from mt5_feed import load_mt5_data
+
+app = Flask(__name__)
+bot = ScalpingBot(balance=10000.0)
+
+@app.route('/')
+def index():
+    return render_template('index.html', trades=bot.trade_history)
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    file = request.files.get('file')
+    if file:
+        df = pd.read_csv(file, parse_dates=['time'])
+        df.set_index('time', inplace=True)
+        for i in range(60, len(df)):
+            window = df.iloc[i-60:i+1]
+            signal = bot.evaluate_signals(window)
+            if signal:
+                price = window.iloc[-1].close
+                bot.place_order(signal, price)
+    return redirect(url_for('index'))
+
+@app.route('/mt5', methods=['POST'])
+def run_mt5():
+    symbol = request.form.get('symbol', 'EURUSD')
+    start = pd.to_datetime(request.form['start'])
+    end = pd.to_datetime(request.form['end'])
+    df = load_mt5_data(symbol, start, end)
+    for i in range(60, len(df)):
+        window = df.iloc[i-60:i+1]
+        signal = bot.evaluate_signals(window)
+        if signal:
+            price = window.iloc[-1].close
+            bot.place_order(signal, price)
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/mt5_feed.py
+++ b/mt5_feed.py
@@ -1,0 +1,33 @@
+import os
+from datetime import datetime
+import pandas as pd
+
+try:
+    import MetaTrader5 as mt5
+except ImportError:  # pragma: no cover - optional dependency
+    mt5 = None
+
+
+def _ensure_initialized() -> None:
+    if mt5 is None:
+        raise RuntimeError("MetaTrader5 package is not installed")
+    if mt5.terminal_info() is None:
+        login = int(os.getenv("MT5_LOGIN", 0))
+        password = os.getenv("MT5_PASSWORD")
+        server = os.getenv("MT5_SERVER")
+        if not mt5.initialize(login=login, password=password, server=server):
+            raise RuntimeError(f"MT5 initialize failed: {mt5.last_error()}")
+
+
+def load_mt5_data(symbol: str, start: datetime, end: datetime) -> pd.DataFrame:
+    """Load historical data from MetaTrader 5."""
+    _ensure_initialized()
+    rates = mt5.copy_rates_range(symbol, mt5.TIMEFRAME_M5, start, end)
+    mt5.shutdown()
+    if rates is None:
+        raise RuntimeError(f"Failed to copy rates: {mt5.last_error()}")
+    df = pd.DataFrame(rates)
+    df['time'] = pd.to_datetime(df['time'], unit='s')
+    df.rename(columns={'open': 'open', 'high': 'high', 'low': 'low', 'close': 'close'}, inplace=True)
+    df.set_index('time', inplace=True)
+    return df[['open', 'high', 'low', 'close']]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  publish = "templates"
+  command = ""
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/scalping_bot.py
+++ b/scalping_bot.py
@@ -1,0 +1,161 @@
+"""Simple scalping bot example.
+
+This module implements the core logic of a EUR/USD scalping strategy. It does not
+connect to any broker or execute real trades. The functions are designed for
+educational use and can be adapted to a real trading platform.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, time, timezone
+from pathlib import Path
+from typing import List, Optional
+import csv
+
+import pandas as pd
+
+
+@dataclass
+class Candle:
+    """Represents a single candlestick."""
+
+    time: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+
+
+class ScalpingBot:
+    """EUR/USD scalping strategy using SMA, EMA and RSI."""
+
+    def __init__(self, balance: float, journal_path: str = "journal.csv") -> None:
+        self.balance = balance
+        self.position = None
+        self.consecutive_losses = 0
+        self.daily_losses = 0.0
+        self.trade_history: List[dict] = []
+        self.journal_path = Path(journal_path)
+
+    @staticmethod
+    def _is_london_session(ts: datetime) -> bool:
+        """Return True if `ts` is within the London session."""
+        london_open = time(8, 0)
+        london_close = time(16, 0)
+        overlap_open = time(13, 0)
+        # Overlap close is same as london_close
+        return london_open <= ts.time() <= london_close
+
+    def _calculate_indicators(self, candles: pd.DataFrame) -> pd.DataFrame:
+        """Return DataFrame with SMA, EMA and RSI added."""
+        df = candles.copy()
+        df["sma20"] = df["close"].rolling(window=20).mean()
+        df["sma50"] = df["close"].rolling(window=50).mean()
+        df["ema60"] = df["close"].ewm(span=60, adjust=False).mean()
+        delta = df["close"].diff()
+        up = delta.clip(lower=0)
+        down = -delta.clip(upper=0)
+        roll_up = up.rolling(14).mean()
+        roll_down = down.rolling(14).mean()
+        rs = roll_up / roll_down
+        df["rsi14"] = 100 - (100 / (1 + rs))
+        return df
+
+    def _calculate_lot_size(self, stop_pips: float) -> float:
+        """Calculate lot size risking 2% of account balance."""
+        risk_amount = self.balance * 0.02
+        pip_value_per_lot = 10.0  # $10 per pip for 1 lot on EUR/USD
+        lot_size = risk_amount / (stop_pips * pip_value_per_lot)
+        return lot_size
+
+    def _record_trade(
+        self,
+        direction: str,
+        entry: float,
+        exit_price: float,
+        result: float,
+        reason: str,
+    ) -> None:
+        record = {
+            "time": datetime.now(timezone.utc).isoformat(),
+            "direction": direction,
+            "entry": entry,
+            "exit": exit_price,
+            "result": result,
+            "reason": reason,
+        }
+        self.trade_history.append(record)
+        write_header = not self.journal_path.exists()
+        with self.journal_path.open("a", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=record.keys())
+            if write_header:
+                writer.writeheader()
+            writer.writerow(record)
+
+    def evaluate_signals(self, candles: pd.DataFrame) -> Optional[str]:
+        """Return 'buy', 'sell' or None based on latest candle."""
+        df = self._calculate_indicators(candles)
+        last = df.iloc[-1]
+        prev = df.iloc[-2]
+
+        if not self._is_london_session(last.name.to_pydatetime()):
+            return None
+
+        bullish = last.close > last.open and prev.close < prev.open
+        bearish = last.close < last.open and prev.close > prev.open
+
+        if (
+            last.close > last.sma20 > last.sma50 < float("inf")
+            and last.close > last.ema60
+            and last.sma20 > last.sma50
+            and last.rsi14 > 50
+            and bullish
+        ):
+            return "buy"
+        if (
+            last.close < last.sma20 < last.sma50 < float("inf")
+            and last.close < last.ema60
+            and last.sma20 < last.sma50
+            and last.rsi14 < 50
+            and bearish
+        ):
+            return "sell"
+        return None
+
+    def place_order(self, direction: str, price: float, stop_pips: float = 15.0) -> None:
+        """Mock placing an order and recording it."""
+        lot_size = self._calculate_lot_size(stop_pips)
+        # In a real system, an API call would be made here.
+        print(f"Placing {direction} order: lot {lot_size:.2f} at {price}")
+        # Record trade for demonstration
+        self._record_trade(direction, price, price, 0.0, "entry")
+
+    # Additional methods for managing open positions would go here.
+
+
+def load_csv(path: str) -> pd.DataFrame:
+    """Utility to load candle data from CSV."""
+    df = pd.read_csv(path, parse_dates=["time"])
+    df.set_index("time", inplace=True)
+    return df
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run scalping bot on CSV data")
+    parser.add_argument("csv", help="CSV file with columns: time,open,high,low,close")
+    parser.add_argument("--journal", default="journal.csv", help="Path to trade journal CSV")
+    args = parser.parse_args()
+
+    data = load_csv(args.csv)
+    bot = ScalpingBot(balance=10000.0, journal_path=args.journal)
+
+    for i in range(60, len(data)):
+        window = data.iloc[i - 60 : i + 1]
+        signal = bot.evaluate_signals(window)
+        if signal:
+            price = window.iloc[-1].close
+            bot.place_order(signal, price)
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Scalping Bot</title>
+</head>
+<body>
+    <h1>Scalping Bot</h1>
+    <form action="/upload" method="post" enctype="multipart/form-data">
+        <input type="file" name="file">
+        <button type="submit">Run on CSV</button>
+    </form>
+    <h2>Run on MT5</h2>
+    <form action="/mt5" method="post">
+        Symbol: <input type="text" name="symbol" value="EURUSD"><br>
+        Start: <input type="datetime-local" name="start"><br>
+        End: <input type="datetime-local" name="end"><br>
+        <button type="submit">Fetch and Run</button>
+    </form>
+    <h2>Recent Trades</h2>
+    <table border="1">
+        <tr>
+            <th>Time</th><th>Direction</th><th>Entry</th><th>Exit</th><th>Result</th><th>Reason</th>
+        </tr>
+        {% for trade in trades %}
+        <tr>
+            <td>{{ trade.time }}</td>
+            <td>{{ trade.direction }}</td>
+            <td>{{ trade.entry }}</td>
+            <td>{{ trade.exit }}</td>
+            <td>{{ trade.result }}</td>
+            <td>{{ trade.reason }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>

--- a/tests/test_scalping_bot.py
+++ b/tests/test_scalping_bot.py
@@ -1,0 +1,68 @@
+import pandas as pd
+from datetime import datetime, timezone
+
+from scalping_bot import ScalpingBot
+
+def test_lot_size():
+    bot = ScalpingBot(balance=10000)
+    size = bot._calculate_lot_size(10)
+    assert round(size, 4) == 2.0
+
+
+def test_is_london_session():
+    bot = ScalpingBot(balance=1000)
+    dt_in = datetime(2020, 1, 1, 9, 0, tzinfo=timezone.utc)
+    assert bot._is_london_session(dt_in)
+    dt_out = datetime(2020, 1, 1, 7, 59, tzinfo=timezone.utc)
+    assert not bot._is_london_session(dt_out)
+    dt_close = datetime(2020, 1, 1, 16, 0, tzinfo=timezone.utc)
+    assert bot._is_london_session(dt_close)
+    dt_after = datetime(2020, 1, 1, 16, 1, tzinfo=timezone.utc)
+    assert not bot._is_london_session(dt_after)
+
+
+def test_calculate_indicators():
+    data = [
+        {
+            "time": datetime(2020, 1, 1, 8, 0, tzinfo=timezone.utc) + pd.Timedelta(minutes=5 * i),
+            "open": 1 + i * 0.001,
+            "high": 1 + i * 0.001 + 0.0005,
+            "low": 1 + i * 0.001 - 0.0005,
+            "close": 1 + i * 0.001 + 0.0002,
+        }
+        for i in range(60)
+    ]
+    df = pd.DataFrame(data).set_index("time")
+    bot = ScalpingBot(balance=1000)
+    out = bot._calculate_indicators(df)
+    last = out.iloc[-1]
+    assert last["sma20"] > 0
+    assert last["ema60"] > 0
+    assert last["rsi14"] >= 0
+
+
+def test_evaluate_signals_buy():
+    # create upward trending data to trigger buy signal
+    data = []
+    for i in range(60):
+        ts = datetime(2020, 1, 1, 8, 0, tzinfo=timezone.utc) + pd.Timedelta(minutes=5 * i)
+        if i == 59:
+            open_price = 1 + 0.01 * i - 0.002
+            close = 1 + 0.01 * i
+        elif i == 58:
+            open_price = 1 + 0.01 * i
+            close = open_price - 0.002
+        else:
+            open_price = 1 + 0.01 * i - 0.0002
+            close = 1 + 0.01 * i
+        data.append({
+            "time": ts,
+            "open": open_price,
+            "high": max(open_price, close),
+            "low": min(open_price, close),
+            "close": close,
+        })
+    df = pd.DataFrame(data).set_index("time")
+    bot = ScalpingBot(balance=1000)
+    signal = bot.evaluate_signals(df)
+    assert signal == "buy"


### PR DESCRIPTION
## Summary
- extend `ScalpingBot` with journal persistence
- add optional MetaTrader5 data loader
- create simple Flask web interface
- document journal, MT5 usage and Netlify deployment
- expand unit tests for trading logic

## Testing
- `pip install pandas flask`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447f39d504832595266d83ad81dc85